### PR TITLE
Causes URL to wrap and not overflow

### DIFF
--- a/app/components/elements/BibliographyItem.tsx
+++ b/app/components/elements/BibliographyItem.tsx
@@ -13,7 +13,7 @@ const BibliographyItem = ({
   return (
     <div className="BibliographyItem flex">
       <dt className="w-20 shrink-0 font-bold">{label}</dt>
-      <dt>{value}</dt>
+      <dt className="break-all">{value}</dt>
     </div>
   )
 }


### PR DESCRIPTION
# Summary
#2 Fixes the word-wrapping. We could also use `overflow-scroll` functionality alternatively. This change should impact all bibliography items-- not just the URLs.  