### PR TITLE
Filters out order string when order string is "0"

### DIFF
--- a/app/components/quicklinks/QuickLinks.tsx
+++ b/app/components/quicklinks/QuickLinks.tsx
@@ -8,6 +8,12 @@ interface QuickLinksProps {
 }
 
 const QuickLinks = ({ data }: QuickLinksProps): JSX.Element => {
+  function filterOrderString(meaningOrder: string | null): string | null {
+    const validMeaningOrder: boolean =
+      meaningOrder !== null && meaningOrder !== "0"
+    return validMeaningOrder ? meaningOrder : ""
+  }
+
   return (
     <div className="mt-2 mr-5 hidden w-96 shrink-0 overflow-hidden  md:block">
       <div className="fixed w-96 overflow-hidden ">
@@ -26,7 +32,9 @@ const QuickLinks = ({ data }: QuickLinksProps): JSX.Element => {
                     key={meaning.id}
                     scrollToId={`meaning-${meaning.id}`}
                   >
-                    <span className="ml-2 font-bold">{meaning.order}</span>{" "}
+                    <span className="ml-2 font-bold">
+                      {filterOrderString(meaning.order)}
+                    </span>{" "}
                     <SanitizedTextSpan text={meaning.definition} />
                   </QuickLink>
                 ))}


### PR DESCRIPTION
# Summary
#5 Makes it such that in the case where the order string is "0", the 0 is not rendered and is filtered out.

## Notes
I think it might be possible for there to be an entry in which the order string is 0 but there are multiple orders, such that the 0 is actually important. I can't find any cases of this at the moment and decided to not spend too much time worrying about it.

## Database Cleanup Notes
You're probably aware, but the database might need some clean up in some areas. I noticed that there are a number of Meaning records that have `Order = 0` and `Definition = ""`, in which case I'm not sure if the meaning record should be there.