### PR TITLE
rewrite Entry Updating to use TYPE_MAP rather than switch statement

### DIFF
--- a/app/components/Entry.tsx
+++ b/app/components/Entry.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-import Headword from "~/components/Headword"
+import Headword from "~/components/headwordComponents/Headword"
 import Meanings from "~/components/Meanings"
 import type { LoadedDataType } from "~/routes/entries/$headword"
 import QuickLinks from "./quicklinks/QuickLinks"

--- a/app/components/Entry.tsx
+++ b/app/components/Entry.tsx
@@ -30,6 +30,7 @@ const Entry = ({ data }: EntryProps): JSX.Element => {
             alternatives={data.spelling_variants || ""}
             generalLabels={data.general_labels || ""}
             handNote={data.fist_note || ""}
+            hasDagger={data.dagger}
             etymology={data.etymology || ""}
             isLegacy={data.is_legacy}
             isNonCanadian={data.no_cdn_conf}

--- a/app/components/Headword.tsx
+++ b/app/components/Headword.tsx
@@ -10,6 +10,7 @@ interface HeadwordProps {
   etymology?: string
   generalLabels?: string
   handNote?: string
+  hasDagger?: boolean
   isLegacy: boolean
   isNonCanadian?: boolean
   word: string
@@ -21,6 +22,7 @@ const Headword = ({
   etymology,
   generalLabels,
   handNote,
+  hasDagger,
   isLegacy,
   isNonCanadian,
   word,
@@ -30,7 +32,10 @@ const Headword = ({
     <div className="flex flex-col gap-2 leading-tight md:gap-4" id="headword">
       <div className="flex items-center justify-between">
         <div className="flex justify-center align-middle">
-          <h1 className="text-3xl leading-tight md:text-5xl">{word}</h1>
+          <h1 className="text-3xl leading-tight md:text-5xl">
+            {word}
+            {hasDagger && <span className="align-super">&dagger;</span>}
+          </h1>
           <EditingPopover
             headword={word}
             currentValue={word}

--- a/app/components/Headword.tsx
+++ b/app/components/Headword.tsx
@@ -40,14 +40,23 @@ const Headword = ({
         </div>
         <DictionaryVersion isLegacy={isLegacy} />
       </div>
-      {alternatives && (
-        <h2 className="leading-tight text-slate-700 md:text-xl">
-          <span className="text-slate-500">Spelling variants:</span>{" "}
-          <span className="italic">
-            <SanitizedTextSpan text={alternatives} />
-          </span>
-        </h2>
-      )}
+      <div className="flex flex-row">
+        {alternatives && (
+          <h2 className="leading-tight text-slate-700 md:text-xl">
+            <span className="text-slate-500">Spelling variants:</span>{" "}
+            <span className="italic">
+              <SanitizedTextSpan text={alternatives} />
+            </span>
+          </h2>
+        )}
+        <EditingPopover
+          headword={word}
+          currentValue={alternatives}
+          attributeType={attributeEnum.SPELLING_VARIANT}
+          attributeID={id}
+          type={editablePopoverInputTypes.TEXTAREA}
+        />
+      </div>
       <div className="flex flex-row">
         <p>
           {etymology && (
@@ -77,11 +86,20 @@ const Headword = ({
           attributeID={id}
         />
       </div>
-      {handNote && (
-        <HandNoteBlock className="text-xs text-slate-500 md:text-lg">
-          {handNote}
-        </HandNoteBlock>
-      )}
+      <div className="flex flex-row">
+        {handNote && (
+          <HandNoteBlock className="text-xs text-slate-500 md:text-lg">
+            {handNote}
+          </HandNoteBlock>
+        )}
+        <EditingPopover
+          headword={word}
+          currentValue={handNote}
+          attributeType={attributeEnum.FIST_NOTE}
+          attributeID={id}
+          type={editablePopoverInputTypes.TEXTAREA}
+        />
+      </div>
       {isNonCanadian && (
         <div className="border border-red-300 bg-red-200 p-3 font-bold">
           Non-Canadianism

--- a/app/components/headwordComponents/Alternatives.tsx
+++ b/app/components/headwordComponents/Alternatives.tsx
@@ -1,0 +1,21 @@
+import SanitizedTextSpan from "../SanitizedTextSpan"
+
+interface alternativesProps {
+  alternatives: string | undefined
+}
+
+const Alternatives = ({ alternatives }: alternativesProps): JSX.Element => {
+  const authenticated: boolean = true // TODO: use authentication variable
+  if (!alternatives && !authenticated) return <></>
+
+  return (
+    <h2 className="leading-tight text-slate-700 md:text-xl">
+      <span className="text-slate-500">Spelling variants:</span>{" "}
+      <span className="italic">
+        <SanitizedTextSpan text={alternatives || "-- none --"} />
+      </span>
+    </h2>
+  )
+}
+
+export default Alternatives

--- a/app/components/headwordComponents/Etymology.tsx
+++ b/app/components/headwordComponents/Etymology.tsx
@@ -1,0 +1,20 @@
+import SanitizedTextSpan from "../SanitizedTextSpan"
+
+interface etymologyProps {
+  etymology: string | undefined
+}
+
+const Etymology = ({ etymology }: etymologyProps): JSX.Element => {
+  const authenticated: boolean = true // TODO: use authentication variable
+  if (!etymology && !authenticated) return <></>
+
+  return (
+    <p>
+      <span className="ml-3 italic">
+        <SanitizedTextSpan text={etymology || "-- none --"} />
+      </span>
+    </p>
+  )
+}
+
+export default Etymology

--- a/app/components/headwordComponents/GeneralLabels.tsx
+++ b/app/components/headwordComponents/GeneralLabels.tsx
@@ -1,0 +1,20 @@
+import SanitizedTextSpan from "../SanitizedTextSpan"
+
+interface generalLabelsProps {
+  generalLabels: string | undefined
+}
+
+const GeneralLabels = ({ generalLabels }: generalLabelsProps): JSX.Element => {
+  const authenticated: boolean = true // TODO: use authentication variable
+  if (!generalLabels && !authenticated) return <></>
+
+  return (
+    <p>
+      <span className="ml-3 italic">
+        <SanitizedTextSpan text={generalLabels || "-- none --"} />
+      </span>
+    </p>
+  )
+}
+
+export default GeneralLabels

--- a/app/components/headwordComponents/Headword.tsx
+++ b/app/components/headwordComponents/Headword.tsx
@@ -1,9 +1,11 @@
-import DictionaryVersion from "./DictionaryVersion"
-import HandNoteBlock from "./HandNoteBlock"
-import SanitizedTextSpan from "./SanitizedTextSpan"
-import { attributeEnum } from "./editing/attributeEnum"
-import { editablePopoverInputTypes } from "./editing/EditablePopoverInput"
-import EditingPopover from "./editing/EditingPopover"
+import DictionaryVersion from "../DictionaryVersion"
+import HandNoteBlock from "../HandNoteBlock"
+import { attributeEnum } from "../editing/attributeEnum"
+import { editablePopoverInputTypes } from "../editing/EditablePopoverInput"
+import EditingPopover from "../editing/EditingPopover"
+import GeneralLabels from "./GeneralLabels"
+import Etymology from "./Etymology"
+import Alternatives from "./Alternatives"
 
 interface HeadwordProps {
   alternatives?: string
@@ -46,14 +48,7 @@ const Headword = ({
         <DictionaryVersion isLegacy={isLegacy} />
       </div>
       <div className="flex flex-row">
-        {alternatives && (
-          <h2 className="leading-tight text-slate-700 md:text-xl">
-            <span className="text-slate-500">Spelling variants:</span>{" "}
-            <span className="italic">
-              <SanitizedTextSpan text={alternatives} />
-            </span>
-          </h2>
-        )}
+        <Alternatives alternatives={alternatives} />
         <EditingPopover
           headword={word}
           currentValue={alternatives}
@@ -63,13 +58,7 @@ const Headword = ({
         />
       </div>
       <div className="flex flex-row">
-        <p>
-          {etymology && (
-            <span className="">
-              <SanitizedTextSpan text={etymology} />
-            </span>
-          )}
-        </p>
+        <Etymology etymology={etymology} />
         <EditingPopover
           headword={word}
           currentValue={etymology}
@@ -77,13 +66,7 @@ const Headword = ({
           attributeID={id}
           type={editablePopoverInputTypes.TEXTAREA}
         />
-        <p>
-          {generalLabels && (
-            <span className="ml-3 italic">
-              <SanitizedTextSpan text={generalLabels} />
-            </span>
-          )}
-        </p>
+        <GeneralLabels generalLabels={generalLabels} />
         <EditingPopover
           headword={word}
           currentValue={generalLabels}

--- a/app/models/entry.server.ts
+++ b/app/models/entry.server.ts
@@ -1,4 +1,3 @@
-import { attributeEnum } from "~/components/editing/attributeEnum"
 import type { Entry } from "@prisma/client"
 import { prisma } from "~/db.server"
 import { isNonPositive } from "~/utils/numberUtils"
@@ -126,51 +125,4 @@ export function getEntriesByInitialLetters(
   return prisma.$queryRaw<
     Pick<Entry, "id" | "headword">[]
   >`SELECT id, headword FROM det_entries WHERE LOWER(headword) LIKE LOWER(${initialLettersWildcard}) ORDER BY LOWER(headword) ASC LIMIT ${take} OFFSET ${skip}`
-}
-
-export async function updateRecordByAttributeAndType(
-  type: attributeEnum,
-  id: number,
-  value: string
-) {
-  if (isNaN(id)) {
-    throw new Error(`Error Parsing ID of element being edited`)
-  } else if (isNonPositive(id)) {
-    throw new Error(`Error Parsing Type and ID of element being edited`)
-  }
-
-  switch (type) {
-    case attributeEnum.HEADWORD:
-      await updateEntryHeadword(id, value)
-      break
-    case attributeEnum.ETYMOLOGY:
-      await updateEntryEtymology(id, value)
-      break
-    case attributeEnum.LABELS:
-      await updateEntryLabels(id, value)
-      break
-    default:
-      throw new Error("Type of element being edited is not supported")
-  }
-}
-
-export async function updateEntryHeadword(entryId: number, newValue: string) {
-  await prisma.entry.update({
-    where: { id: entryId },
-    data: { headword: newValue },
-  })
-}
-
-export async function updateEntryEtymology(entryId: number, newValue: string) {
-  await prisma.entry.update({
-    where: { id: entryId },
-    data: { etymology: newValue },
-  })
-}
-
-export async function updateEntryLabels(entryId: number, newValue: string) {
-  await prisma.entry.update({
-    where: { id: entryId },
-    data: { general_labels: newValue },
-  })
 }

--- a/app/models/update.server.ts
+++ b/app/models/update.server.ts
@@ -1,0 +1,32 @@
+import { attributeEnum } from "~/components/editing/attributeEnum"
+import { prisma } from "~/db.server"
+import { assertIsValidId } from "~/utils/numberUtils"
+
+const ENTRY_TYPE_MAP = {
+  [attributeEnum.HEADWORD]: "headword",
+  [attributeEnum.ETYMOLOGY]: "etymology",
+  [attributeEnum.LABELS]: "general_labels",
+  [attributeEnum.SPELLING_VARIANT]: "spelling_variants",
+  [attributeEnum.FIST_NOTE]: "fist_note",
+  [attributeEnum.DAGGER]: "dagger",
+}
+
+export async function updateRecordByAttributeAndType(
+  type: attributeEnum,
+  id: number,
+  value: string
+) {
+  assertIsValidId(id)
+  await updateEntry(id, type, value)
+}
+
+async function updateEntry(
+  entryId: number,
+  type: attributeEnum,
+  newValue: string
+) {
+  await prisma.entry.update({
+    where: { id: entryId },
+    data: { [ENTRY_TYPE_MAP[type]]: newValue },
+  })
+}

--- a/app/routes/entries/$headword.tsx
+++ b/app/routes/entries/$headword.tsx
@@ -3,10 +3,9 @@ import { redirect, type ActionArgs, type LoaderArgs } from "@remix-run/node"
 import { useCatch, useLoaderData } from "@remix-run/react"
 import invariant from "tiny-invariant"
 
-import {
-  getEntryByHeadword,
-  updateRecordByAttributeAndType,
-} from "~/models/entry.server"
+import { getEntryByHeadword } from "~/models/entry.server"
+import { updateRecordByAttributeAndType } from "~/models/update.server"
+
 import Entry from "~/components/Entry"
 import {
   getAttributeEnumFromFormInput,

--- a/app/utils/numberUtils.ts
+++ b/app/utils/numberUtils.ts
@@ -1,3 +1,11 @@
 export function isNonPositive(number: number) {
-    return number <= 0;
+  return number <= 0
+}
+
+export function assertIsValidId(id: number) {
+  if (isNaN(id)) {
+    throw new Error(`Given ID must be a number`)
+  } else if (isNonPositive(id)) {
+    throw new Error(`Given ID must be positive`)
+  }
 }


### PR DESCRIPTION
# Summary
closes #61 #63 

This PR accomplishes three things:
1. Uses TypeMap rather than a switch statement to handle entry updating, as per previous PR feedback
2. Adds editing functionality for Spelling Variants and Fistnotes (only headword fistnotes)
3. Refactors `Headword` into separate classes to allow for easier default text and more control over the display

