### PR TITLE
Fix type warnings

### DIFF
--- a/app/components/editing/EditingPopover.tsx
+++ b/app/components/editing/EditingPopover.tsx
@@ -8,8 +8,8 @@ import EditablePopoverInput, {
 } from "./EditablePopoverInput"
 
 interface Props {
-  headword: string
-  currentValue: string | undefined
+  headword?: string
+  currentValue?: string
   attributeType: attributeEnum
   attributeID: number
   type?: editablePopoverInputTypes


### PR DESCRIPTION
The merge into `main` from #109 got screwed up somehow 😢 I think this fixes it.