### PR TITLE
Add DCHP-3.1 search option and fix date display

### DIFF
--- a/app/components/EntryEditor/DictionaryVersion.tsx
+++ b/app/components/EntryEditor/DictionaryVersion.tsx
@@ -17,8 +17,20 @@ const calculateDictionaryVersion = (
 
   if (!logEntries) return { version: `Unknown`, date: `Post-DCHP-1` }
 
+  // Filter log entries based on DCHP version cutoff dates
+  let filteredLogEntries = logEntries
+  if (dchpVersion === "dchp3") {
+    // Filter to log entries after April 2025
+    const april2025 = new Date("2025-04-01").getTime()
+    filteredLogEntries = logEntries.filter(entry => Date.parse(entry.created) >= april2025)
+  } else if (dchpVersion === "dchp3.1") {
+    // Filter to log entries after June 2025
+    const june2025 = new Date("2025-06-01").getTime()
+    filteredLogEntries = logEntries.filter(entry => Date.parse(entry.created) >= june2025)
+  }
+
   // Find the *earliest* log entry (when this was created)
-  const logEntry = [...logEntries]
+  const logEntry = [...filteredLogEntries]
     .sort((a, b) => {
       const aTime = Date.parse(a.created)
       const bTime = Date.parse(b.created)
@@ -33,7 +45,7 @@ const calculateDictionaryVersion = (
   const localeMonth = date.toLocaleString(`en-ca`, { month: "short" })
 
   const version =
-    dchpVersion === `dchp3.1` ? `dchp3.1` : `DCHP-${year >= 2018 ? 3 : 2}`
+    dchpVersion === `dchp3.1` ? `DCHP-3.1` : `DCHP-${year >= 2018 ? 3 : 2}`
 
   return { version, date: `${localeMonth} ${year}` }
 }

--- a/app/components/elements/Labels/DictionaryVersionLabel.tsx
+++ b/app/components/elements/Labels/DictionaryVersionLabel.tsx
@@ -14,7 +14,7 @@ export default function DictionaryVersionLabel({
 
   return (
     <div
-      className={`inline-block w-12 border text-center ${color} mr-2 px-1 py-0 text-xs uppercase text-gray-700 shadow-sm`}
+      className={`inline-block w-16 border text-center ${color} mr-2 px-1 py-0 text-xs uppercase text-gray-700 shadow-sm`}
     >
       {dchpVersion}
     </div>

--- a/app/components/search/DatabaseCheckboxes.tsx
+++ b/app/components/search/DatabaseCheckboxes.tsx
@@ -25,6 +25,7 @@ export default function DatabaseCheckboxes({
           { label: "DCHP-1", value: "dchp1", defaultChecked: true },
           { label: "DCHP-2", value: "dchp2", defaultChecked: true },
           { label: "DCHP-3", value: "dchp3", defaultChecked: true },
+          { label: "DCHP-3.1", value: "dchp3.1", defaultChecked: true },
         ]}
       />
     </div>


### PR DESCRIPTION
- Add DCHP-3.1 as searchable option in Database section
- Increase label width from w-12 to w-16 for better DCHP-3.1 display
- Filter log entries for date calculation: DCHP-3 uses entries after April 2025, DCHP-3.1 uses entries after June 2025

Changes made with assistance from Claude Code