### PR TITLE
Fix search filtering to properly handle canadianism type filters

### DIFF
--- a/app/models/search.server.ts
+++ b/app/models/search.server.ts
@@ -23,6 +23,8 @@ export type SearchResultParams = SearchActionSchema & {
   isUserAdmin: boolean
   take: number
   skip: number
+  canadianismTypes: string[]
+  versions: string[]
 }
 
 export type AllSearchResults = {

--- a/app/models/search/getEntriesByBasicTextSearch.ts
+++ b/app/models/search/getEntriesByBasicTextSearch.ts
@@ -5,6 +5,7 @@ import type { Entry } from "../entry.server"
 import type { SearchResultParams } from "../search.server"
 import { DEFAULT_PAGE_SIZE } from "~/utils/pageSize"
 import { EDITING_STATUS_INPUTS } from "~/components/EntryEditor/EntryEditorSidebar/EditingStatus/EditingStatusPanel"
+import { BASE_CANADANISM_TYPES } from "~/types/CanadianismTypeEnum"
 
 export const editingStatusHelper = (editingStatus: string[] | undefined) => {
   const allStatuses =
@@ -27,11 +28,46 @@ export function getHeadwordCount({
   isUserAdmin = false,
   nonCanadianism,
   editingStatus,
+  canadianismTypes,
 }: SearchResultParams) {
   const searchWildcard =
     searchTerm === SEARCH_WILDCARD ? "%" : `%${searchTerm}%`
 
   const { allStatuses, statusMap } = editingStatusHelper(editingStatus)
+
+  // Check if we need to filter by canadianism types
+  const needsCanadianismFilter = canadianismTypes && canadianismTypes.length !== BASE_CANADANISM_TYPES.length
+
+  if (needsCanadianismFilter) {
+    return prisma.$queryRaw<{ count: number }[]>`
+    SELECT
+      count(DISTINCT de.id) as count
+    FROM det_entries de
+    INNER JOIN det_meanings dm ON de.id = dm.entry_id
+    WHERE
+      IF (${caseSensitive},
+        (de.headword) LIKE (${searchWildcard}) OR de.spelling_variants LIKE (${searchWildcard}),
+        (LOWER(de.headword) LIKE LOWER(${searchWildcard})) OR LOWER(de.spelling_variants) LIKE LOWER(${searchWildcard})
+      )
+      AND (de.dchp_version IN (${Prisma.join(database)}))
+      AND (de.is_public = 1 OR ${isUserAdmin})
+      AND (de.no_cdn_conf = 1 OR NOT ${nonCanadianism === true})
+      AND (dm.canadianism_type IN (${Prisma.join(canadianismTypes)}))
+      AND (${allStatuses} OR (
+        (de.first_draft = 1 AND ${statusMap["first_draft"] === true}) OR
+        (de.revised_draft = 1 AND ${statusMap["revised_draft"] === true}) OR
+        (de.semantically_revised = 1 AND ${
+          statusMap["semantically_revised"] === true
+        }) OR
+        (de.edited_for_style = 1 AND ${statusMap["edited_for_style"] === true}) OR
+        (de.proofread = 1 AND ${statusMap["proofread"] === true}) OR
+        (de.chief_editor_ok = 1 AND ${statusMap["chief_editor_ok"] === true}) OR
+        (de.final_proofing = 1 AND ${statusMap["final_proofing"] === true}) OR
+        (de.no_cdn_susp = 1 AND ${statusMap["no_cdn_susp"] === true}) OR
+        (de.no_cdn_conf = 1 AND ${statusMap["no_cdn_conf"] === true})
+      ))
+    `
+  }
 
   return prisma.$queryRaw<{ count: number }[]>`
   SELECT
@@ -70,11 +106,49 @@ export function getEntriesByBasicTextSearch({
   isUserAdmin = false,
   nonCanadianism,
   editingStatus,
+  canadianismTypes,
 }: SearchResultParams) {
   const searchWildcard =
     searchTerm === SEARCH_WILDCARD ? "%" : `%${searchTerm}%`
 
   const { allStatuses, statusMap } = editingStatusHelper(editingStatus)
+
+  // Check if we need to filter by canadianism types
+  const needsCanadianismFilter = canadianismTypes && canadianismTypes.length !== BASE_CANADANISM_TYPES.length
+
+  if (needsCanadianismFilter) {
+    return prisma.$queryRaw<
+      Pick<Entry, "id" | "headword" | "dchp_version" | "is_public">[]
+    >`
+    SELECT DISTINCT
+      de.id, de.headword, de.is_public, de.dchp_version
+    FROM det_entries de
+    INNER JOIN det_meanings dm ON de.id = dm.entry_id
+    WHERE
+      IF (${caseSensitive},
+        (de.headword) LIKE (${searchWildcard}) OR de.spelling_variants LIKE (${searchWildcard}),
+        (LOWER(de.headword) LIKE LOWER(${searchWildcard})) OR LOWER(de.spelling_variants) LIKE LOWER(${searchWildcard})
+      )
+      AND (de.dchp_version IN (${Prisma.join(database)}))
+      AND (de.is_public = 1 OR ${isUserAdmin})
+      AND (de.no_cdn_conf = 1 OR NOT ${nonCanadianism === true})
+      AND (dm.canadianism_type IN (${Prisma.join(canadianismTypes)}))
+      AND (${allStatuses} OR (
+        (de.first_draft = 1 AND ${statusMap["first_draft"] === true}) OR
+        (de.revised_draft = 1 AND ${statusMap["revised_draft"] === true}) OR
+        (de.semantically_revised = 1 AND ${
+          statusMap["semantically_revised"] === true
+        }) OR
+        (de.edited_for_style = 1 AND ${statusMap["edited_for_style"] === true}) OR
+        (de.proofread = 1 AND ${statusMap["proofread"] === true}) OR
+        (de.chief_editor_ok = 1 AND ${statusMap["chief_editor_ok"] === true}) OR
+        (de.final_proofing = 1 AND ${statusMap["final_proofing"] === true}) OR
+        (de.no_cdn_susp = 1 AND ${statusMap["no_cdn_susp"] === true}) OR
+        (de.no_cdn_conf = 1 AND ${statusMap["no_cdn_conf"] === true})
+      ))
+    ORDER BY LOWER(de.headword) ASC LIMIT ${take} OFFSET ${skip}
+    `
+  }
 
   return prisma.$queryRaw<
     Pick<Entry, "id" | "headword" | "dchp_version" | "is_public">[]


### PR DESCRIPTION
- Add canadianismTypes and versions to SearchResultParams type
- Update getHeadwordCount to filter by canadianism type when specified
- Update getEntriesByBasicTextSearch to join with meanings table for canadianism filtering
- Use DISTINCT to avoid duplicate entries when filtering by canadianism type
- Fixes issue where searching with Type 6 + DCHP-3 returned all entries instead of filtered results

Changes made with assistance from Claude Code